### PR TITLE
fix: bump node version to the latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Node 10 image
-FROM node:10
+FROM node:16
 
 # Change directory to /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
`10` has been deprecated and the image is no longer available on docker hub

## Test

Build a new image

```bash
docker build -t node-build-config-openshift .
```

Run it

```bash
docker run --rm -p 8080:8080 node-build-config-openshift
```

Curl the endpoint and the express server returns some HTML response as expected

```bash
curl localhost:8080
```